### PR TITLE
feat: add aos library for scroll animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "uni-stirling-grade-calculator-website",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "aos": "^2.3.4"
+      },
       "devDependencies": {
         "tailwindcss": "^3.2.4"
       }
@@ -92,6 +95,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aos": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/aos/-/aos-2.3.4.tgz",
+      "integrity": "sha512-zh/ahtR2yME4I51z8IttIt4lC1Nw0ktsFtmeDzID1m9naJnWXhCoARaCgNOGXb5CLy3zm+wqmRAEgMYB5E2HUw==",
+      "dependencies": {
+        "classlist-polyfill": "^1.0.3",
+        "lodash.debounce": "^4.0.6",
+        "lodash.throttle": "^4.0.1"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -166,6 +179,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "node_modules/color-name": {
       "version": "1.1.4",
@@ -378,6 +396,16 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -862,6 +890,16 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aos": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/aos/-/aos-2.3.4.tgz",
+      "integrity": "sha512-zh/ahtR2yME4I51z8IttIt4lC1Nw0ktsFtmeDzID1m9naJnWXhCoARaCgNOGXb5CLy3zm+wqmRAEgMYB5E2HUw==",
+      "requires": {
+        "classlist-polyfill": "^1.0.3",
+        "lodash.debounce": "^4.0.6",
+        "lodash.throttle": "^4.0.1"
+      }
+    },
     "arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -915,6 +953,11 @@
           }
         }
       }
+    },
+    "classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
     },
     "color-name": {
       "version": "1.1.4",
@@ -1074,6 +1117,16 @@
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
       "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "homepage": "https://github.com/Project-Roundtable/Uni-Stirling-Grade-Calculator-Website#readme",
   "devDependencies": {
     "tailwindcss": "^3.2.4"
+  },
+  "dependencies": {
+    "aos": "^2.3.4"
   }
 }

--- a/src/honours-calculator.html
+++ b/src/honours-calculator.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Calculate your undergraduate honours degree for University of Stirling.">
     <link rel="stylesheet" href="css/main.css">
+    <!-- TODO: We may have to change this pathing when it comes to deploying, but this is fine for now. -->
+    <link rel="stylesheet" href="../node_modules/aos/dist/aos.css">
     <title>Degree Calculator - Stirling | Honours Calculator</title>
 </head>
 <body class="h-screen">
@@ -52,5 +54,8 @@
         </div>
     </footer>
 
+  <!-- TODO: We may have to change this pathing when it comes to deploying, but this is fine for now. -->   
+  <script src="../node_modules/aos/dist/aos.js"></script>
+  <script>AOS.init()</script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Calculate your honours, masters or module results for University of Stirling.">
     <link rel="stylesheet" href="css/main.css">
+    <!-- TODO: We may have to change this pathing when it comes to deploying, but this is fine for now. -->
+    <link rel="stylesheet" href="../node_modules/aos/dist/aos.css">
     <title>Degree Calculator - Stirling | Home</title>
 </head>
 <body class="h-screen">
@@ -105,6 +107,9 @@
             <p class="pr-9">&copy; Project Roundtable 2022</p>
         </div>
     </footer>
-
+    
+  <!-- TODO: We may have to change this pathing when it comes to deploying, but this is fine for now. -->   
+  <script src="../node_modules/aos/dist/aos.js"></script>
+  <script>AOS.init()</script>
 </body>
 </html>


### PR DESCRIPTION
Adds the aos library to our existing pages. (https://michalsnik.github.io/aos/). When adding to new pages follow the same pattern. I'm not sure if this approach will work very well when we come to deploy so I've left a reminder just in case. There is a CDN option, so perhaps that would be an alternative. This is fine for now though and it appears to be working as expected

Closes #9 